### PR TITLE
Dont allow suggestions to be greater than 25 characters in length

### DIFF
--- a/src/rich-responses/suggestions-response.js
+++ b/src/rich-responses/suggestions-response.js
@@ -55,7 +55,7 @@ class Suggestion extends RichResponse {
       );
     }
     if (
-        suggestion.length > 25 || suggestion.title > 25
+        suggestion.length > 25 || (suggestion.title && suggestion.title.length > 25)
     ) {
         throw new Error(
             'Maximum suggestion length is 25 characters'

--- a/src/rich-responses/suggestions-response.js
+++ b/src/rich-responses/suggestions-response.js
@@ -54,6 +54,13 @@ class Suggestion extends RichResponse {
         'Reply string required by Suggestion constructor'
       );
     }
+    if (
+        suggestion.length > 25 || suggestion.title > 25
+    ) {
+        throw new Error(
+            'Maximum suggestion length is 25 characters'
+        );
+    }
     if (typeof suggestion === 'string') {
       this.replies.push(suggestion);
     } else if (typeof suggestion === 'object') {

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -77,6 +77,15 @@ test('Test v2 Google Assistant responses', async (t) => {
     }
   );
 
+  // Suggestion Max Length
+  const suggestionLengthError = t.throws(() => {
+    new Suggestion('This is a suggestion longer than 25 characters');
+  }, Error);
+  t.is(
+      suggestionLengthError.message,
+      'Maximum suggestion length is 25 characters'
+  );
+
   // Payload
   webhookTest(
     googleRequest,

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -86,6 +86,15 @@ test('Test v2 Google Assistant responses', async (t) => {
       'Maximum suggestion length is 25 characters'
   );
 
+  // Suggestion Title Max Length
+  const suggestionTitleLengthError = t.throws(() => {
+    new Suggestion({title: 'This is a suggestion longer than 25 characters'});
+  }, Error);
+  t.is(
+      suggestionTitleLengthError.message,
+      'Maximum suggestion length is 25 characters'
+  );
+
   // Payload
   webhookTest(
     googleRequest,


### PR DESCRIPTION
[The spec says that suggestions can be 25 characters max](https://developers.google.com/actions/assistant/responses)

The constructor should enforce this (fail early etc) 

I was surprised by this behavior.  To complicate matters, it silently fails in assistant (at least for iOS for me) so it's quite surprising / difficult to debug