### PR TITLE
Remove AoG dependency and turn it into a user supplied type registration

### DIFF
--- a/docs/WebhookClient.md
+++ b/docs/WebhookClient.md
@@ -9,24 +9,27 @@ Dialogflow's simulator
 
 * [WebhookClient](#WebhookClient)
     * [new WebhookClient(options)](#new_WebhookClient_new)
-    * [.agentVersion](#WebhookClient+agentVersion) : <code>number</code>
-    * [.intent](#WebhookClient+intent) : <code>string</code>
-    * [.action](#WebhookClient+action) : <code>string</code>
-    * [.parameters](#WebhookClient+parameters) : <code>Array.&lt;Object&gt;</code>
-    * [.contexts](#WebhookClient+contexts) : <code>string</code>
-    * [.requestSource](#WebhookClient+requestSource) : <code>string</code>
-    * [.originalRequest](#WebhookClient+originalRequest) : <code>object</code>
-    * [.query](#WebhookClient+query) : <code>string</code>
-    * [.locale](#WebhookClient+locale) : <code>string</code>
-    * [.session](#WebhookClient+session) : <code>string</code>
-    * [.add(response)](#WebhookClient+add)
-    * [.handleRequest(handler)](#WebhookClient+handleRequest) ⇒ <code>Promise</code>
-    * [.setContext(context)](#WebhookClient+setContext) ⇒ [<code>WebhookClient</code>](#WebhookClient)
-    * [.clearOutgoingContexts()](#WebhookClient+clearOutgoingContexts) ⇒ [<code>WebhookClient</code>](#WebhookClient)
-    * [.clearContext(context)](#WebhookClient+clearContext) ⇒ [<code>WebhookClient</code>](#WebhookClient)
-    * [.getContext(contextName)](#WebhookClient+getContext) ⇒ <code>Object</code>
-    * [.setFollowupEvent(event)](#WebhookClient+setFollowupEvent)
-    * [.conv()](#WebhookClient+conv) ⇒ <code>DialogflowConversation</code> \| <code>null</code>
+    * _instance_
+        * [.agentVersion](#WebhookClient+agentVersion) : <code>number</code>
+        * [.intent](#WebhookClient+intent) : <code>string</code>
+        * [.action](#WebhookClient+action) : <code>string</code>
+        * [.parameters](#WebhookClient+parameters) : <code>Array.&lt;Object&gt;</code>
+        * [.contexts](#WebhookClient+contexts) : <code>string</code>
+        * [.requestSource](#WebhookClient+requestSource) : <code>string</code>
+        * [.originalRequest](#WebhookClient+originalRequest) : <code>object</code>
+        * [.query](#WebhookClient+query) : <code>string</code>
+        * [.locale](#WebhookClient+locale) : <code>string</code>
+        * [.session](#WebhookClient+session) : <code>string</code>
+        * [.add(response)](#WebhookClient+add)
+        * [.handleRequest(handler)](#WebhookClient+handleRequest) ⇒ <code>Promise</code>
+        * [.setContext(context)](#WebhookClient+setContext) ⇒ [<code>WebhookClient</code>](#WebhookClient)
+        * [.clearOutgoingContexts()](#WebhookClient+clearOutgoingContexts) ⇒ [<code>WebhookClient</code>](#WebhookClient)
+        * [.clearContext(context)](#WebhookClient+clearContext) ⇒ [<code>WebhookClient</code>](#WebhookClient)
+        * [.getContext(contextName)](#WebhookClient+getContext) ⇒ <code>Object</code>
+        * [.setFollowupEvent(event)](#WebhookClient+setFollowupEvent)
+        * [.conv()](#WebhookClient+conv) ⇒ <code>DialogflowConversation</code> \| <code>null</code>
+    * _static_
+        * [.registerActionsOnGoogle(actionsOnGoogle)](#WebhookClient.registerActionsOnGoogle)
 
 <a name="new_WebhookClient_new"></a>
 
@@ -225,6 +228,29 @@ Get Actions on Google DialogflowConversation object
 **Example**  
 ```js
 const { WebhookClient } = require('dialogflow-webhook');
+WebhookClient.registerActionsOnGoogle(require('actions-on-google'));
+const agent = new WebhookClient({request: request, response: response});
+let conv = agent.conv();
+conv.ask('Hi from the Actions on Google client library');
+agent.add(conv);
+```
+<a name="WebhookClient.registerActionsOnGoogle"></a>
+
+### WebhookClient.registerActionsOnGoogle(actionsOnGoogle)
+Registers the Actions on Google library instance.
+Must be called once before any calls to [conv](#WebhookClient+conv) method are made.
+
+**Kind**: static method of [<code>WebhookClient</code>](#WebhookClient)
+
+| Param | Type |
+| --- | --- |
+| actionsOnGoogle | <code>Object</code> |
+| actionsOnGoogle.DialogflowConversation | <code>Object</code> |
+
+**Example**
+```js
+const { WebhookClient } = require('dialogflow-webhook');
+WebhookClient.registerActionsOnGoogle(require('actions-on-google'));
 const agent = new WebhookClient({request: request, response: response});
 let conv = agent.conv();
 conv.ask('Hi from the Actions on Google client library');

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "fulfillment"
   ],
   "dependencies": {
-    "debug": "^2.2.0",
-    "actions-on-google": "2.0.0-alpha.4"
+    "debug": "^2.2.0"
   },
   "devDependencies": {
     "ava": "^0.24.0",
@@ -46,6 +45,7 @@
     "eslint-config-google": "^0.9.1",
     "jsdoc-to-markdown": "^4.0.1",
     "jszip": "^3.1.5",
-    "commander": "^2.15.1"
+    "commander": "^2.15.1",
+    "actions-on-google": "2.0.0-alpha.4"
   }
 }

--- a/samples/actions-on-google/functions/index.js
+++ b/samples/actions-on-google/functions/index.js
@@ -23,6 +23,8 @@ const { Carousel } = require('actions-on-google');
 
 process.env.DEBUG = 'dialogflow:debug'; // enables lib debugging statements
 
+WebhookClient.registerActionsOnGoogle(require('actions-on-google'));
+
 const imageUrl = 'https://developers.google.com/actions/images/badges/XPM_BADGING_GoogleAssistant_VER.png';
 const imageUrl2 = 'https://lh3.googleusercontent.com/Nu3a6F80WfixUqf_ec_vgXy_c0-0r4VLJRXjVFF_X_CIilEu8B9fT35qyTEj_PEsKw';
 const linkUrl = 'https://assistant.google.com/';

--- a/test/webhook-test.js
+++ b/test/webhook-test.js
@@ -148,6 +148,8 @@ function actionsOnGoogleTest(request, callback) {
     response: response,
   });
 
+  WebhookClient.registerActionsOnGoogle(require('actions-on-google'));
+
   agent.handleRequest( (agent) => {
     let conv = agent.conv();
     conv.ask('Hi');


### PR DESCRIPTION
@matthewayne I'm not sure what you think about this PR but it fixes #33 in a very explicit way. 

In this way of working, the user of the fulfillment library is responsible for registering the `actions-on-google` library to the `WebhookClient` explicitly before using any Actions on Google specific code in the client. This way, we can be sure that only a single instance of the `actions-on-google` library is used.

This does _not_, however, do any version or type checks on the supplied AoG library. If you accept this work and want such a check, I can add that as well.