### PR TITLE
Add an appendMode to the agent

### DIFF
--- a/docs/WebhookClient.md
+++ b/docs/WebhookClient.md
@@ -20,6 +20,7 @@ Dialogflow's simulator
     * [.locale](#WebhookClient+locale) : <code>string</code>
     * [.session](#WebhookClient+session) : <code>string</code>
     * [.add(response)](#WebhookClient+add)
+    * [.enableAppendMode](#WebhookClient+enableAppendMode)
     * [.handleRequest(handler)](#WebhookClient+handleRequest) ⇒ <code>Promise</code>
     * [.setContext(context)](#WebhookClient+setContext) ⇒ [<code>WebhookClient</code>](#WebhookClient)
     * [.clearOutgoingContexts()](#WebhookClient+clearOutgoingContexts) ⇒ [<code>WebhookClient</code>](#WebhookClient)
@@ -119,6 +120,22 @@ Add a response to be sent to Dialogflow
 | Param | Type | Description |
 | --- | --- | --- |
 | response | [<code>RichResponse</code>](#RichResponse) \| <code>string</code> | an object or string representing the rich response to be added |
+
+<a name="WebhookClient+enableAppendMode"></a>
+
+### webhookClient.enableAppendMode(enable)
+Enables or disables the append mode.
+
+When enabled, the append mode adds fulfillmentMessages to the request ones.
+
+This is useful if you want to keep the DialogFlow original messages.
+
+**Kind**: instance method of [<code>WebhookClient</code>](#WebhookClient)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| enable | <code>boolean</code> | should the append mode be enabled
+
 
 <a name="WebhookClient+handleRequest"></a>
 

--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -173,6 +173,12 @@ class WebhookClient {
     this.session = null;
 
     /**
+     * Activation of the append mode that keeps the original fulfillmentMessages
+     * from the queryResult inputed through the request
+     */
+    this.appendModeEnabled_ = false;
+
+    /**
      * Platform contants, to define platforms, includes supported platforms and unspecified
      * @example
      * const { WebhookClient } = require('dialogflow-webhook');
@@ -204,6 +210,7 @@ class WebhookClient {
   // ---------------------------------------------------------------------------
   //                   Generic Methods
   // ---------------------------------------------------------------------------
+
   /**
    * Add a response to be sent to Dialogflow
    *
@@ -264,6 +271,15 @@ class WebhookClient {
         .status('No handler for requested intent');
       return Promise.reject(new Error('No handler for requested intent'));
     }
+  }
+
+/**
+ * Enables or disables the appendMode
+ * Disabled by default
+ * @param {boolean} enabled
+ */
+  enableAppendMode(enabled) {
+    this.appendModeEnabled_ = Boolean(enabled);
   }
 
   // --------------------------------------------------------------------------

--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -167,7 +167,9 @@ class V2Agent {
    * @private
    */
   sendMessagesResponse_(requestSource) {
-    this.sendJson_({fulfillmentMessages: this.buildResponseMessages_(requestSource)});
+    this.sendJson_({
+      fulfillmentMessages: this.buildResponseMessages_(requestSource, this.agent.appendModeEnabled_),
+    });
   }
 
   /**
@@ -189,13 +191,21 @@ class V2Agent {
    * developer defined responses and the request source
    *
    * @param {string} requestSource string indicating the source of the initial request
+   * @param {boolean} append boolean indicating if the messages should be appended to the
+   *                          original queryResult messages or erase them
    * @return {Object[]} message objects
    * @private
    */
-  buildResponseMessages_(requestSource) {
+  buildResponseMessages_(requestSource, append) {
     const responseMessages = this.agent.responseMessages_
       .map((message) => message.getV2ResponseObject_(requestSource))
       .filter((arr) => arr);
+
+    if (append) {
+      const requestMessages = this.agent.request_.body.queryResult.fulfillmentMessages;
+      return [...requestMessages, ...responseMessages];
+    }
+
     return responseMessages;
   }
 

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -22,7 +22,7 @@
 const test = require('ava');
 
 const {WebhookClient} = require('../src/dialogflow-fulfillment');
-const {Card, Image, Suggestion, Payload} = require('../src/dialogflow-fulfillment');
+const {Text, Card, Image, Suggestion, Payload} = require('../src/dialogflow-fulfillment');
 
 const imageUrl = `https://assistant.google.com/static/images/molecule/\
 Molecule-Formation-stop.png`;
@@ -374,6 +374,23 @@ test('Test v2 followup events', async (t) => {
   t.deepEqual(complexEvent, agent.followupEvent_);
 });
 
+test('Test v2 append', async (t) => {
+  let request = {body: mockV2ResponseWithMessage};
+
+  webhookTest(
+    request,
+    (agent) => {
+      agent.enableAppendMode(true);
+      agent.add(new Text('Text message 1 added from the fulfillment'));
+      agent.add(new Text('Text message 2 added from the fulfillment'));
+    },
+    (responseJson) => {
+      t.is(responseJson.fulfillmentMessages.length, 3);
+      t.is(responseJson.fulfillmentMessages[2].text.text[0], 'Text message 2 added from the fulfillment');
+    }
+  );
+});
+
 test('Test v1 original request', async (t) => {
   let response = new ResponseMock();
 
@@ -487,6 +504,29 @@ function addCard(agent) {
     })
   );
 }
+
+const mockV2ResponseWithMessage = {
+  responseId: '07424698-0149-430a-9b9c-157402568343',
+  queryResult: {
+    queryText: 'webhook',
+    parameters: {},
+    allRequiredParamsPresent: true,
+    fulfillmentText: '',
+    fulfillmentMessages: [
+      {text: {text: ['text response']}},
+    ],
+    outputContexts: [],
+    intent: {
+      name: `projects/stagent-f2236/agent/intents/\
+29bcd7f8-f717-4261-a8fd-2d3e451b8af8`,
+      displayName: 'webhook',
+    },
+    intentDetectionConfidence: 1,
+    diagnosticInfo: {},
+    languageCode: 'en-us',
+  },
+  session: 'projects/stagent-f2236/agent/sessions/1515017715285',
+};
 
 const responseFacebookV2Payload = {
   payload: {


### PR DESCRIPTION
I have a use case where I just want to add some suggestions to an intent I fully configured on the DialogFlow UI.

I find it frustrating to have to update the fulfillment code for the wordings when I can update them directly from the DialogFlow UI.

So, I'd like to add an append mode where the fulfillmentMessages we add are append to the original fulfillmentMessages configured in DialogFlow and passed through the queryResults.fulfillmentMessages attribute on the request.

I'm really opened if you know a better way to do it, but it seems that the case should be handled into the webhook.