### PR TITLE
Allow to build RichResponses from outside the library

### DIFF
--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -514,4 +514,15 @@ class WebhookClient {
   }
 }
 
-module.exports = {WebhookClient, Text, Card, Image, Suggestion, Payload};
+
+module.exports = {
+  WebhookClient,
+  Text,
+  Card,
+  Image,
+  Suggestion,
+  Payload,
+  RichResponse,
+  PLATFORMS,
+  SUPPORTED_RICH_MESSAGE_PLATFORMS,
+};


### PR DESCRIPTION
As Github doesn't allow the edition of PR source branch after creation - I had to create a new one.
See Original PR at #77 

Expose RichResponse object from outside the library so that it can be extended.

My usecase is the following. I have custom UI components into my chat, and I'd like to return multiple custom payloads. Ideally, my goal is to be able to return them into my fulfillment as simply as I would return Text.

```js
agent.add(new Text('Here is the weather in Paris'));
agent.add(new Weather('Paris', 'cloudy', 32));
agent.add(new Text('And the weather in SF'));
agent.add(new Weather('SF', 'sunny', 41));
```

I tried to use Payloads to do that
```js
agent.add(new Text('Here is the weather in Paris'));
agent.add(new Payload(PLATFORM_UNSPECIFIED, {city: 'Paris', sky: 'cloudy', temp: 32}));
agent.add(new Text('And the weather in SF'));
agent.add(new Payload(PLATFORM_UNSPECIFIED, city: 'SF', sky: 'sunny', temp: 42}));
```

But the library has a limitation that the dialogflow V2 API doesn't have : we can't set multiple payloads for the same platform. If we do, we get an error message like 'PLATFORM_UNSPECIFIED already has a payload').

Originally, I wanted to make a PR so that multiple Payloads can be added for the v2 API - but it seems to be heavy to do.

So I tried to extend RichResponse and set my own payload object and it works fine - and that's not that heavy to add into the lib.

What's your opinion about this ?
