### PR TITLE
Send payloads as messages with default integrations

### DIFF
--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -499,7 +499,7 @@ class WebhookClient {
       || SUPPORTED_PLATFORMS.indexOf(this.requestSource) < 0) {
       this.client.addMessagesResponse_(requestSource);
     }
-    if (payload) {
+    if (payload && !payload.sendAsMessage) {
       this.client.addPayloadResponse_(payload, requestSource);
     }
     this.client.sendResponses_(requestSource);


### PR DESCRIPTION
Payload rich responses will now only be included once in the final response JSON. The payload will end up in "fulfillmentMessages[]" or "webhookPayload", but not both. See Payload#sendAsMessage.

This fixes some default integrations, like Facebook, that will ignore "fulfillmentMessages" if "webhookPayload" is present.