### PR TITLE
Setting followup event json before declaring that no response is defined

### DIFF
--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -96,8 +96,8 @@ class V2Agent {
      * @type {string}
      */
     if (this.agent.request_.body.queryResult.outputContexts) {
-      this.agent.contexts = this.agent.request_.body.queryResult.outputContexts
-        .map((context) => this.convertV2ContextToV1Context_(context));
+      this.agent.contexts = this.agent.request_.body.queryResult.outputContexts.map(
+        (context) => this.convertV2ContextToV1Context_(context));
     } else {
       this.agent.contexts = [];
     }
@@ -149,8 +149,8 @@ class V2Agent {
      * Original request language code (i.e. "en")
      * @type {string} locale language code indicating the spoken/written language of the original request
      */
-     this.agent.locale = this.agent.request_.body.queryResult.languageCode;
-     debug(`Request locale: ${JSON.stringify(this.agent.query)}`);
+    this.agent.locale = this.agent.request_.body.queryResult.languageCode;
+    debug(`Request locale: ${JSON.stringify(this.agent.query)}`);
 
     /**
      * List of messages defined in Dialogflow's console for the matched intent
@@ -239,14 +239,17 @@ class V2Agent {
    */
   sendResponses_(requestSource) {
     let responseJson = this.responseJson_;
+
+    if (this.agent.followupEvent_) {
+      responseJson = responseJson || {};
+      responseJson.followupEventInput = this.agent.followupEvent_;
+    }
+
     if (!responseJson) {
       throw new Error(`No responses defined for platform: ${requestSource}`);
     }
 
     responseJson.outputContexts = this.agent.context.getV2OutputContextsArray();
-    if (this.agent.followupEvent_) {
-      responseJson.followupEventInput = this.agent.followupEvent_;
-    }
     if (this.agent.endConversation_) {
       responseJson.triggerEndOfConversation = this.agent.endConversation_;
     }
@@ -264,9 +267,8 @@ class V2Agent {
    * @private
    */
   buildResponseMessages_(requestSource) {
-    return this.agent.responseMessages_
-      .map((message) => message.getV2ResponseObject_(requestSource))
-      .filter((arr) => arr);
+    return this.agent.responseMessages_.map((message) => message.getV2ResponseObject_(requestSource)).
+      filter((arr) => arr);
   }
 
   /**
@@ -332,14 +334,14 @@ class V2Agent {
    */
   addActionsOnGoogle_(response) {
     if (response.outputContexts) {
-      response.outputContexts.forEach( (context) => {
+      response.outputContexts.forEach((context) => {
         this.addContext_(context);
       });
     }
 
     this.agent.add(new PayloadResponse(
       PLATFORMS.ACTIONS_ON_GOOGLE,
-      response.payload.google)
+      response.payload.google),
     );
   }
 
@@ -366,13 +368,13 @@ class V2Agent {
     let richConsoleMessages = []; // list of messages to be returned
 
     // iterate through each message recived in the webhook request
-    consoleMessageList.forEach( (consoleMessageJson) => {
+    consoleMessageList.forEach((consoleMessageJson) => {
       const richMessageType = Object.keys(consoleMessageJson).find((key) => key !== 'platform');
       if (richResponseMapping[richMessageType]) {
         const messagePlatform = consoleMessageJson.platform ? consoleMessageJson.platform : undefined;
         // convert the JSON to fufillment classes
         let richResponse = richResponseMapping[richMessageType](consoleMessageJson, messagePlatform);
-        richResponse ? richConsoleMessages = richConsoleMessages.concat(richResponse): null;
+        richResponse ? richConsoleMessages = richConsoleMessages.concat(richResponse) : null;
       } else {
         debug(`Unsupported console message type "${richMessageType}"`);
       }
@@ -389,8 +391,11 @@ class V2Agent {
    * @private
    */
   convertTextJson_(messageJson, platform) {
-    if (!messageJson.text.text[0]) return null;
-    else return new Text({text: messageJson.text.text[0], platform: platform});
+    if (!messageJson.text.text[0]) {
+      return null;
+    } else {
+      return new Text({text: messageJson.text.text[0], platform: platform});
+    }
   }
 
   /**
@@ -402,14 +407,14 @@ class V2Agent {
    * @private
    */
   convertCardJson_(messageJson, platform) {
-   return new Card({
-          title: messageJson.card.title || ' ',
-          text: messageJson.card.subtitle,
-          imageUrl: messageJson.card.imageUri,
-          buttonText: messageJson.card.buttons ? messageJson.card.buttons[0].text: null,
-          buttonUrl: messageJson.card.buttons ? messageJson.card.buttons[0].postback: null,
-          platform: platform,
-        });
+    return new Card({
+      title: messageJson.card.title || ' ',
+      text: messageJson.card.subtitle,
+      imageUrl: messageJson.card.imageUri,
+      buttonText: messageJson.card.buttons ? messageJson.card.buttons[0].text : null,
+      buttonUrl: messageJson.card.buttons ? messageJson.card.buttons[0].postback : null,
+      platform: platform,
+    });
   }
 
   /**
@@ -421,10 +426,10 @@ class V2Agent {
    * @private
    */
   convertImageJson_(messageJson, platform) {
-   return new Image({
-     imageUrl: messageJson.image.imageUri,
-     platform: platform,
-   });
+    return new Image({
+      imageUrl: messageJson.image.imageUri,
+      platform: platform,
+    });
   }
 
   /**
@@ -453,11 +458,11 @@ class V2Agent {
   convertQuickRepliesJson_(messageJson, platform) {
     if (!messageJson.suggestions) return null;
     let suggestions = [];
-    messageJson.suggestions.forEach( (consoleMessageJson, iterator) => {
-     suggestions.push(new Suggestion({
-       title: messageJson.quickReplies.quickReplies[iterator],
-       platform: platform,
-     }));
+    messageJson.suggestions.forEach((consoleMessageJson, iterator) => {
+      suggestions.push(new Suggestion({
+        title: messageJson.quickReplies.quickReplies[iterator],
+        platform: platform,
+      }));
     });
     return suggestions;
   }
@@ -471,10 +476,10 @@ class V2Agent {
    * @private
    */
   convertSimpleResponsesJson_(messageJson, platform) {
-   return new Text({
-     text: messageJson.simpleResponses.simpleResponses[0].textToSpeech,
-     platform: platform,
-   });
+    return new Text({
+      text: messageJson.simpleResponses.simpleResponses[0].textToSpeech,
+      platform: platform,
+    });
   }
 
   /**
@@ -486,14 +491,14 @@ class V2Agent {
    * @private
    */
   convertBasicCardJson_(messageJson, platform) {
-   return new Card({
-          title: messageJson.basicCard.title || ' ',
-          text: messageJson.basicCard.formattedText,
-          imageUrl: messageJson.basicCard.image ? messageJson.basicCard.image.imageUri : null,
-          buttonText: messageJson.basicCard.buttons ? messageJson.basicCard.buttons[0].title : null,
-          buttonUrl: messageJson.basicCard.buttons ? messageJson.basicCard.buttons[0].openUriAction.uri : null,
-          platform: platform,
-        });
+    return new Card({
+      title: messageJson.basicCard.title || ' ',
+      text: messageJson.basicCard.formattedText,
+      imageUrl: messageJson.basicCard.image ? messageJson.basicCard.image.imageUri : null,
+      buttonText: messageJson.basicCard.buttons ? messageJson.basicCard.buttons[0].title : null,
+      buttonUrl: messageJson.basicCard.buttons ? messageJson.basicCard.buttons[0].openUriAction.uri : null,
+      platform: platform,
+    });
   }
 
   /**
@@ -507,11 +512,11 @@ class V2Agent {
   convertSuggestionsJson_(messageJson, platform) {
     if (!messageJson.suggestions) return null;
     let suggestions = [];
-    messageJson.suggestions.suggestions.forEach( (consoleMessageJson, iterator) => {
-     suggestions.push(new Suggestion({
-       title: messageJson.suggestions.suggestions[iterator].title,
-       platform: platform,
-     }));
+    messageJson.suggestions.suggestions.forEach((consoleMessageJson, iterator) => {
+      suggestions.push(new Suggestion({
+        title: messageJson.suggestions.suggestions[iterator].title,
+        platform: platform,
+      }));
     });
     return suggestions;
   }

--- a/test/webhook-v1-test.js
+++ b/test/webhook-v1-test.js
@@ -262,6 +262,30 @@ test('Test v1 followup events', async (t) => {
   t.deepEqual(complexEventJson, agent.followupEvent_);
 });
 
+test('Test v1 followupEvent only response', async (t) => {
+  // Request with Knowledge connector response
+  let request = {body: mockGoogleV1Request};
+  const complexEvent = {
+    name: 'weather',
+    parameters: {city: 'Rome'},
+    languageCode: 'en',
+  };
+  const complexEventJson = {
+    name: 'weather',
+    data: {city: 'Rome'},
+  };
+
+  webhookTest(
+    request,
+    (agent) => {
+      agent.setFollowupEvent(complexEvent);
+    },
+    (responseJson) => {
+      t.deepEqual(responseJson.followupEvent, complexEventJson);
+    },
+  );
+});
+
 test('Test v1 original request', async (t) => {
   let response = new ResponseMock();
 

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -39,12 +39,12 @@ test('Test v2 Google Assistant responses', async (t) => {
   // Google Assistant Request: text response
   webhookTest(
     googleRequest,
-    (agent)=>{
+    (agent) => {
       agent.add('text response');
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseGoogleV2Text);
-    }
+    },
   );
 
   // Google Assistant Request: card response
@@ -53,40 +53,40 @@ test('Test v2 Google Assistant responses', async (t) => {
     addCard,
     (responseJson) => {
       t.deepEqual(responseJson, responseGoogleV2Card);
-    }
+    },
   );
 
   // Image response
   webhookTest(
     googleRequest,
-    (agent)=>{
+    (agent) => {
       agent.add(new Image(imageUrl));
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseGoogleV2Image);
-    }
+    },
   );
 
   // Suggestion
   webhookTest(
     googleRequest,
-    (agent)=>{
+    (agent) => {
       agent.add(new Suggestion('sample reply'));
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseGoogleV2Suggestion);
-    }
+    },
   );
 
   // Payload
   webhookTest(
     googleRequest,
-    (agent)=>{
+    (agent) => {
       agent.add(new Payload(agent.ACTIONS_ON_GOOGLE, googlePayload));
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseGoogleV2Payload);
-    }
+    },
   );
 });
 
@@ -98,7 +98,7 @@ test('Test v2 Slack responses', async (t) => {
     addCard,
     (responseJson) => {
       t.deepEqual(responseJson, responseSlackV2Card);
-    }
+    },
   );
 
   // TextResponse and CardResponse
@@ -109,11 +109,11 @@ test('Test v2 Slack responses', async (t) => {
   // TextReponse
   webhookTest(slackRequest,
     (agent) => {
-agent.add('text response');
-},
+      agent.add('text response');
+    },
     (responseJson) => {
-t.deepEqual(responseJson, responseSlackV2Text);
-  });
+      t.deepEqual(responseJson, responseSlackV2Text);
+    });
 
   // ImageResponse
   webhookTest(
@@ -123,7 +123,7 @@ t.deepEqual(responseJson, responseSlackV2Text);
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseSlackV2Image);
-    }
+    },
   );
 
   // SuggestionsReponse
@@ -134,7 +134,7 @@ t.deepEqual(responseJson, responseSlackV2Text);
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseSlackV2Suggestions);
-    }
+    },
   );
 
   // PayloadReponse
@@ -145,7 +145,7 @@ t.deepEqual(responseJson, responseSlackV2Text);
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseSlackV2Payload);
-    }
+    },
   );
 });
 
@@ -157,7 +157,7 @@ test('Test v2 Facebook responses', async (t) => {
     addCard,
     (responseJson) => {
       t.deepEqual(responseJson, responseFacebookV2Card);
-    }
+    },
   );
 
   // TextResponse and CardResponse
@@ -166,7 +166,7 @@ test('Test v2 Facebook responses', async (t) => {
     textAndCard,
     (responseJson) => {
       t.deepEqual(responseJson, responseFacebookV2TextAndCard);
-    }
+    },
   );
 
   // TextResponse
@@ -177,7 +177,7 @@ test('Test v2 Facebook responses', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseFacebookV2Text);
-    }
+    },
   );
 
   // ImageResponse
@@ -188,7 +188,7 @@ test('Test v2 Facebook responses', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseFacebookV2Image);
-    }
+    },
   );
 
   // QuickRepliesReponse
@@ -199,7 +199,7 @@ test('Test v2 Facebook responses', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseFacebookV2Suggestion);
-    }
+    },
   );
 
   // PayloadReponse
@@ -210,7 +210,7 @@ test('Test v2 Facebook responses', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson, responseFacebookV2Payload);
-    }
+    },
   );
 });
 
@@ -237,7 +237,7 @@ test('Test v2 Twitter response', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson, {fulfillmentText: textResponse, outputContexts: []});
-    }
+    },
   );
 });
 
@@ -251,7 +251,7 @@ test('Test v2 Twitter payload response', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson, {payload: {twitter: {test: 'payload'}}, outputContexts: []});
-    }
+    },
   );
 });
 
@@ -275,23 +275,23 @@ test('Test v2 contexts', async (t) => {
   agent.setContext(sampleContextName);
   t.deepEqual(
     {name: sampleContextName},
-    agent.context.get(sampleContextName)
+    agent.context.get(sampleContextName),
   );
   agent.setContext(secondContextName);
   t.deepEqual(
     {name: secondContextName},
-    agent.context.get(secondContextName)
+    agent.context.get(secondContextName),
   );
   agent.setContext(complexContext);
   t.deepEqual(
     {name: complexContext.name, lifespan: 2, parameters: {city: 'Rome'}},
-    agent.context.get(complexContext.name)
+    agent.context.get(complexContext.name),
   );
   // clearContext
   agent.clearContext(sampleContextName);
   t.deepEqual(
     undefined,
-    agent.context.get(sampleContextName)
+    agent.context.get(sampleContextName),
   );
   // clearAllContext
   agent.clearOutgoingContexts();
@@ -307,14 +307,16 @@ test('Test converstion of v2 contexts to v1 contexts', async (t) => {
     response: slackResponse,
   });
 
-  t.deepEqual([{
-    name: 'generic',
-    lifespan: 4,
-    parameters: {
-      slack_user_id: 'U2URF86K1',
-      slack_channel: 'D3XQ6AF9A'},
-  }],
-    agent.contexts
+  t.deepEqual([
+      {
+        name: 'generic',
+        lifespan: 4,
+        parameters: {
+          slack_user_id: 'U2URF86K1',
+          slack_channel: 'D3XQ6AF9A',
+        },
+      }],
+    agent.contexts,
   );
 });
 
@@ -329,13 +331,14 @@ test('Test v2 getContext', async (t) => {
 
   let context = agent.getContext('generic');
   t.deepEqual({
-    name: 'generic',
-    lifespan: 4,
-    parameters: {
-      slack_user_id: 'U2URF86K1',
-      slack_channel: 'D3XQ6AF9A'},
-  },
-    context
+      name: 'generic',
+      lifespan: 4,
+      parameters: {
+        slack_user_id: 'U2URF86K1',
+        slack_channel: 'D3XQ6AF9A',
+      },
+    },
+    context,
   );
 
   context = agent.getContext('nonsense');
@@ -367,6 +370,26 @@ test('Test v2 followup events', async (t) => {
   t.deepEqual(complexEvent, agent.followupEvent_);
 });
 
+test('Test v2 followupEvent only response', async (t) => {
+  // Request with Knowledge connector response
+  let request = {body: mockV2KnowledgeConnector};
+  const complexEvent = {
+    name: 'weather',
+    parameters: {city: 'Rome'},
+    languageCode: 'en',
+  };
+
+  webhookTest(
+    request,
+    (agent) => {
+      agent.setFollowupEvent(complexEvent);
+    },
+    (responseJson) => {
+      t.deepEqual(responseJson.followupEventInput, complexEvent);
+    },
+  );
+});
+
 test('Test v2 consoleMessages', async (t) => {
   let request = {body: mockV2ResponseWithMessage};
 
@@ -379,7 +402,7 @@ test('Test v2 consoleMessages', async (t) => {
     (responseJson) => {
       t.is(responseJson.fulfillmentMessages.length, 2);
       t.is(responseJson.fulfillmentMessages[0].text.text[0], 'text response');
-    }
+    },
   );
 
   let response = new ResponseMock();
@@ -408,13 +431,13 @@ test('Test v2 consoleMessages', async (t) => {
   const facebookImage = consoleMessages[3];
   t.true(facebookImage instanceof Image);
   t.is(facebookImage.imageUrl,
-    'https://developers.google.com/actions/images/badges/XPM_BADGING_GoogleAssistant_VER.png'
+    'https://developers.google.com/actions/images/badges/XPM_BADGING_GoogleAssistant_VER.png',
   );
   // Facebook payload
   const facebookPayload = consoleMessages[4];
   t.true(facebookPayload instanceof Payload);
   t.deepEqual(facebookPayload.payload,
-      {'key': 'Facebook Messenger Payload'}
+    {'key': 'Facebook Messenger Payload'},
   );
   // Actions on Google text
   const actionsOnGoogleText = consoleMessages[5];
@@ -441,7 +464,7 @@ test('Test v2 consoleMessages', async (t) => {
   const actionsOnGooglePayload = consoleMessages[10];
   t.true(actionsOnGooglePayload instanceof Payload);
   t.deepEqual(actionsOnGooglePayload.payload,
-      {'google': 'payload'}
+    {'google': 'payload'},
   );
 });
 
@@ -455,7 +478,7 @@ test('Test v2 original request', async (t) => {
   });
 
   t.deepEqual(mockGoogleV2Request.originalDetectIntentRequest,
-    agent.originalRequest
+    agent.originalRequest,
   );
 
   let facebookRequest = {body: mockFacebookV2Request};
@@ -465,7 +488,7 @@ test('Test v2 original request', async (t) => {
   });
 
   t.deepEqual(mockFacebookV2Request.originalDetectIntentRequest,
-    agent.originalRequest
+    agent.originalRequest,
   );
 });
 
@@ -479,7 +502,7 @@ test('Test v2 no handler defined', async (t) => {
   const noHandlerDefinedError = await t.throws(agent.handleRequest(new Map()));
   t.is(
     noHandlerDefinedError.message,
-    'No handler for requested intent'
+    'No handler for requested intent',
   );
 });
 
@@ -492,7 +515,7 @@ test('Test v2 alternative query results', async (t) => {
   });
 
   t.deepEqual(mockV2KnowledgeConnector.alternativeQueryResults,
-    agent.alternativeQueryResults
+    agent.alternativeQueryResults,
   );
 });
 
@@ -507,7 +530,7 @@ test('Test v2 end conversation', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson.triggerEndOfConversation, true);
-    }
+    },
   );
 });
 
@@ -523,6 +546,7 @@ class ResponseMock {
     this.callback = callback;
     this.responseJson = {};
   }
+
   /**
    * Store JSON repsonse from WebhookClient
    * @param {Object} responseJson
@@ -530,6 +554,7 @@ class ResponseMock {
   json(responseJson) {
     this.callback(responseJson);
   }
+
   /**
    * Get JSON response for testing comparison
    * @return {Object} response JSON from WebhookClient
@@ -537,6 +562,7 @@ class ResponseMock {
   get() {
     return this.responseJson;
   }
+
   /**
    * Get status code for testing comparison
    * @param {number} code HTTP status code of response
@@ -546,6 +572,7 @@ class ResponseMock {
     this.responseJson += code;
     return this;
   }
+
   /**
    * Store JSON repsonse from WebhookClient
    * @param {Object} message response object
@@ -582,7 +609,7 @@ function textAndCard(agent) {
       imageUrl: imageUrl,
       buttonText: 'button text',
       buttonUrl: linkUrl,
-    })
+    }),
   );
 };
 
@@ -597,7 +624,7 @@ function addCard(agent) {
       imageUrl: imageUrl,
       buttonText: 'button text',
       buttonUrl: linkUrl,
-    })
+    }),
   );
 }
 
@@ -744,7 +771,7 @@ const responseSlackV2Suggestions = {
   ],
   outputContexts: [],
 };
-  const responseSlackV2Image = {
+const responseSlackV2Image = {
   fulfillmentMessages: [
     {
       image: {


### PR DESCRIPTION
This fixes issue #160.  If you set a followup event only and do not provide a message, you get an error saying that no response is defined.

This fixes the issue by checking for and setting the followup event on the response before declaring that no response has been defined.

It looks like my IDE was a bit zealous with the reformatting (mostly just spacing), but the only relevant changes are in `v1-agent.sendResponses_` and `v2-agent.sendResponses_`.  I added tests for both agents as well.