### PR TITLE
Fixes dialogflow/dialogflow-fulfillment-nodejs#153

### DIFF
--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -371,7 +371,7 @@ class V2Agent {
     consoleMessageList.forEach((consoleMessageJson) => {
       const richMessageType = Object.keys(consoleMessageJson).find((key) => key !== 'platform');
       if (richResponseMapping[richMessageType]) {
-        const messagePlatform = consoleMessageJson.platform ? consoleMessageJson.platform : undefined;
+        const messagePlatform = consoleMessageJson.platform ? consoleMessageJson.platform : PLATFORMS.UNSPECIFIED;
         // convert the JSON to fufillment classes
         let richResponse = richResponseMapping[richMessageType](consoleMessageJson, messagePlatform);
         richResponse ? richConsoleMessages = richConsoleMessages.concat(richResponse) : null;


### PR DESCRIPTION
Platform doesn't seem to be passed in through the request when a custom payload is used in the default response section of Dialogflow Console.

Fix - Set platform to PLATFORM_UNSPECIFIED when using custom payload

https://dialogflow.com/docs/reference/api-v2/rest/Shared.Types/Platform