### PR TITLE
Fixed trigger to end conversation in telephony. Issue #222

### DIFF
--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -251,7 +251,7 @@ class V2Agent {
     } else {
       responseJson.outputContexts = this.agent.context.getV2OutputContextsArray();
       if (this.agent.endConversation_) {
-        responseJson.triggerEndOfConversation = this.agent.endConversation_;
+        responseJson.end_interaction = this.agent.endConversation_;
       }
       debug('Response to Dialogflow: ' + JSON.stringify(responseJson));
       this.agent.response_.json(responseJson);

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -530,7 +530,7 @@ test('Test v2 end conversation', async (t) => {
       agent.end('thanks for talking to me!');
     },
     (responseJson) => {
-      t.deepEqual(responseJson.triggerEndOfConversation, true);
+      t.deepEqual(responseJson.end_interaction, true);
     },
   );
 });


### PR DESCRIPTION
As discussed in issue #222 the end_interaction was not working as the v2 agent was sending triggerEndOfConversation for which dialogflow was giving an error.