### PR TITLE
Telephony fix and no handler found error fix

### DIFF
--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -323,7 +323,7 @@ class WebhookClient {
       error('No handler for requested intent');
       this.response_
         .status(RESPONSE_CODE_BAD_REQUEST)
-        .status('No handler for requested intent');
+        .send('No handler for requested intent');
       return Promise.reject(new Error('No handler for requested intent'));
     }
   }

--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -251,7 +251,7 @@ class V2Agent {
     } else {
       responseJson.outputContexts = this.agent.context.getV2OutputContextsArray();
       if (this.agent.endConversation_) {
-        responseJson.triggerEndOfConversation = this.agent.endConversation_;
+        responseJson.end_interaction = this.agent.endConversation_;
       }
       debug('Response to Dialogflow: ' + JSON.stringify(responseJson));
       this.agent.response_.json(responseJson);

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -530,7 +530,7 @@ test('Test v2 end conversation', async (t) => {
       agent.end('thanks for talking to me!');
     },
     (responseJson) => {
-      t.deepEqual(responseJson.triggerEndOfConversation, true);
+      t.deepEqual(responseJson.end_interaction, true);
     },
   );
 });


### PR DESCRIPTION
This pull request fixes two issues. The telephony issue was that the call was not being ended when triggering agent.end. The other issue was that when no handler matches for the intent, the response was malformed and wasn't getting sent, that has been tested and fixed.