### PR TITLE
Fix for issue #222. Fixed webhook's no handler found error.

### DIFF
--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -323,7 +323,7 @@ class WebhookClient {
       error('No handler for requested intent');
       this.response_
         .status(RESPONSE_CODE_BAD_REQUEST)
-        .status('No handler for requested intent');
+        .send('No handler for requested intent');
       return Promise.reject(new Error('No handler for requested intent'));
     }
   }

--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {debug, error} = require('./common');
+const { debug, error } = require('./common');
 
 // Response Builder classes
 const {
@@ -149,8 +149,8 @@ class V2Agent {
      * Original request language code (i.e. "en")
      * @type {string} locale language code indicating the spoken/written language of the original request
      */
-     this.agent.locale = this.agent.request_.body.queryResult.languageCode;
-     debug(`Request locale: ${JSON.stringify(this.agent.locale)}`);
+    this.agent.locale = this.agent.request_.body.queryResult.languageCode;
+    debug(`Request locale: ${JSON.stringify(this.agent.locale)}`);
 
     /**
      * List of messages defined in Dialogflow's console for the matched intent
@@ -189,7 +189,7 @@ class V2Agent {
   addTextResponse_() {
     const message = this.agent.responseMessages_[0];
     const fulfillmentText = message.ssml || message.text;
-    this.addJson_({fulfillmentText: fulfillmentText});
+    this.addJson_({ fulfillmentText: fulfillmentText });
   }
 
   /**
@@ -201,7 +201,7 @@ class V2Agent {
    * @private
    */
   addPayloadResponse_(payload, requestSource) {
-    this.addJson_({payload: payload.getPayload_(requestSource)});
+    this.addJson_({ payload: payload.getPayload_(requestSource) });
   }
 
   /**
@@ -214,7 +214,7 @@ class V2Agent {
   addMessagesResponse_(requestSource) {
     let messages = this.buildResponseMessages_(requestSource);
     if (messages.length > 0) {
-      this.addJson_({fulfillmentMessages: messages});
+      this.addJson_({ fulfillmentMessages: messages });
     }
   }
 
@@ -394,7 +394,7 @@ class V2Agent {
     if (!messageJson.text.text[0]) {
       return null;
     } else {
-      return new Text({text: messageJson.text.text[0], platform: platform});
+      return new Text({ text: messageJson.text.text[0], platform: platform });
     }
   }
 
@@ -441,6 +441,9 @@ class V2Agent {
    * @private
    */
   convertPayloadJson_(messageJson, platform) {
+    if (!platform) {
+      platform = (messageJson.payload.platform) ? messageJson.payload.platform : 'PLATFORM_UNSPECIFIED';
+    }
     return new PayloadResponse(platform, messageJson.payload, {
       rawPayload: true,
       sendAsMessage: true,

--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -251,7 +251,7 @@ class V2Agent {
     } else {
       responseJson.outputContexts = this.agent.context.getV2OutputContextsArray();
       if (this.agent.endConversation_) {
-        responseJson.triggerEndOfConversation = this.agent.endConversation_;
+        responseJson.end_interaction = this.agent.endConversation_;
       }
       debug('Response to Dialogflow: ' + JSON.stringify(responseJson));
       this.agent.response_.json(responseJson);

--- a/test/webhook-v1-test.js
+++ b/test/webhook-v1-test.js
@@ -325,7 +325,12 @@ test('Test v1 original request', async (t) => {
 });
 
 test('Test v1 no handler defined', async (t) => {
-  let response = new ResponseMock();
+  let response = new ResponseMock((response) => {
+    t.is(
+      response,
+      'No handler for requested intent',
+    );
+  });
   let agent = new WebhookClient({
     request: {body: mockSlackV1Request},
     response: response,

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -493,8 +493,13 @@ test('Test v2 original request', async (t) => {
   );
 });
 
-test('Test v2 no handler defined', async (t) => {
-  let response = new ResponseMock();
+test('Test v2 no handler defined', async t => {
+  let response = new ResponseMock((response) => {
+    t.is(
+      response,
+      'No handler for requested intent',
+    );
+  });
   let agent = new WebhookClient({
     request: {body: mockGoogleV2Request},
     response: response,
@@ -530,7 +535,7 @@ test('Test v2 end conversation', async (t) => {
       agent.end('thanks for talking to me!');
     },
     (responseJson) => {
-      t.deepEqual(responseJson.triggerEndOfConversation, true);
+      t.deepEqual(responseJson.end_interaction, true);
     },
   );
 });


### PR DESCRIPTION
There was an error when an agent.end was triggered and the platform was telephony. The telephony was not disconnecting. Based on the documentation, this has been fixed.
Another error was when a handler was not found for an intent, no response was being sent out because of malformed response. This was also fixed. 
The test cases were modified to match the changes that were made.