### PR TITLE
Fulfillment Text disappeared after adding custom paylaod

### DIFF
--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -497,9 +497,11 @@ class WebhookClient {
       this.client.addTextResponse_();
     } else if (SUPPORTED_RICH_MESSAGE_PLATFORMS.indexOf(this.requestSource) > -1
       || SUPPORTED_PLATFORMS.indexOf(this.requestSource) < 0) {
+      this.client.addTextResponse_();
       this.client.addMessagesResponse_(requestSource);
     }
     if (payload && !payload.sendAsMessage) {
+      this.client.addTextResponse_();
       this.client.addPayloadResponse_(payload, requestSource);
     }
     this.client.sendResponses_(requestSource);


### PR DESCRIPTION
I am using Facebook and Telephony in the same agent. I created a custom Facebook payload and I was not able to see text in Dialogflow history as well as Telephony was not working for me. After adding this code and sending payload as sendAsMessage worked for me.