### PR TITLE
Comment spelling fix

### DIFF
--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -49,7 +49,7 @@ class V2Agent {
   }
 
   /**
-   * Process a v2 Dialogflow webhook request to set class varibles
+   * Process a v2 Dialogflow webhook request to set class variables
    * for action, parameters, contexts, request source and orignal user query
    *
    * @private


### PR DESCRIPTION
Couldn't find the word `variable` when I was parsing through text in the comments. Fixed it.