### PR TITLE
Fix and error to end conversations in Android devices

### DIFF
--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -252,6 +252,7 @@ class V2Agent {
       responseJson.outputContexts = this.agent.context.getV2OutputContextsArray();
       if (this.agent.endConversation_) {
         responseJson.triggerEndOfConversation = this.agent.endConversation_;
+        responseJson.end_interaction = this.agent.endConversation_;
       }
       debug('Response to Dialogflow: ' + JSON.stringify(responseJson));
       this.agent.response_.json(responseJson);

--- a/test/webhook-v2-test.js
+++ b/test/webhook-v2-test.js
@@ -531,6 +531,7 @@ test('Test v2 end conversation', async (t) => {
     },
     (responseJson) => {
       t.deepEqual(responseJson.triggerEndOfConversation, true);
+      t.deepEqual(responseJson.end_interaction, true);
     },
   );
 });


### PR DESCRIPTION
Fix and error to end conversation using Google Assistant in Android devices, because the dialogflow's fulfillment response Json must have the field "end_interaction" with the value true to finishes the conversation.