### PR TITLE
Update contexts.js

### DIFF
--- a/src/contexts.js
+++ b/src/contexts.js
@@ -199,7 +199,8 @@ class Context {
     let contexts = {};
     for (let index = 0; index<v2InputContexts.length; index++) {
       let context = v2InputContexts[index];
-      const name = context['name'].split('/')[6];
+      let name = context['name'].split('/');
+      name = name[name.length-1];
       contexts[name] = {
         name: name,
         lifespan: context['lifespanCount'],


### PR DESCRIPTION
Change _processV2InputContexts(v2InputContexts) function: Extract name not from fixed 6th position,

`const name = context['name'].split('/')[6];`

but from last in the split

`let name = context['name'].split('/');`
`name = name[name.length-1];`

In requests that come in to the draft version contain the context name on the 6th/last position
"name": "projects/project-name/agent/sessions/ABwppplpq8QomdH91Z8YeWbZM1vvK04Ty6-2NEwAe5-Ur3Nc9GUAt3fyguV0YavLfQBNlLhYUFGQY35Gxm913Iefk/contexts/**userdata**"

In alpha test it's not the 6th but it's still the last position. 
"name": "projects/project-name/agent/environments/__aog-30/users/**-**/sessions/ABwppHERR9ORcqJ4vEVSu1XxN3xTolEN7Pq1fUXhOBNaker5yA8ljmI9Wnp8uOZ2rdVVAS4s9Twxa-tjAH45X495K/contexts/userdata"

