### PR TITLE
Fixes #35 Multiple messages not supported with payloads

### DIFF
--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -274,9 +274,7 @@ class WebhookClient {
       this.client.addActionsOnGoogle_(response.serialize());
     } else if (response instanceof Suggestion && this.existingSuggestion_(response.platform)) {
       this.existingSuggestion_(response.platform).addReply_(response.replies[0]);
-    } else if (response instanceof Payload && this.existingPayload_(response.platform)) {
-      throw new Error(`Payload response for ${response.platform} already defined.`);
-    } else if (response instanceof RichResponse) {
+    } else if (response instanceof Payload || response instanceof RichResponse) {
       this.responseMessages_.push(response);
     } else {
       throw new Error(`Unknown response type: "${JSON.stringify(response)}"`);
@@ -492,6 +490,10 @@ class WebhookClient {
     // if platform may support messages, send messages
     // if there is a payload, send the payload for the repsonse
     const payload = this.existingPayload_(requestSource);
+    if (payload && !payload.sendAsMessage) {
+      this.client.addPayloadResponse_(payload, requestSource);
+    }
+
     if (messages.length === 1 &&
       messages[0] instanceof Text) {
       this.client.addTextResponse_();
@@ -499,9 +501,7 @@ class WebhookClient {
       || SUPPORTED_PLATFORMS.indexOf(this.requestSource) < 0) {
       this.client.addMessagesResponse_(requestSource);
     }
-    if (payload && !payload.sendAsMessage) {
-      this.client.addPayloadResponse_(payload, requestSource);
-    }
+
     this.client.sendResponses_(requestSource);
   }
 

--- a/src/rich-responses/payload-response.js
+++ b/src/rich-responses/payload-response.js
@@ -152,6 +152,7 @@ class Payload extends RichResponse {
     return {
       payload: this.getPayload_(this.platform),
       platform: this.platform,
+      sendAsMessage: true,
     };
   }
 }


### PR DESCRIPTION
It's my first day on dialogflow so I am not sure I am doing it correctly. I've just tested it on Facebook and it's okay to send multiple payloads like this:
```
agent.add(new Text({'text': 'hello', 'platform': 'FACEBOOK'}));
agent.add(new Payload('FACEBOOK', {...}, { sendAsMessage:true });
agent.add(new Payload('FACEBOOK', {...}, { sendAsMessage:true });
```

Please don't merge until someone who is working on other integrations gets this PR tested. Your help with this PR is much appreciated. 