### PR TITLE
Exports PLATFORMS as Platforms

### DIFF
--- a/src/dialogflow-fulfillment.js
+++ b/src/dialogflow-fulfillment.js
@@ -560,4 +560,4 @@ class WebhookClient {
   }
 }
 
-module.exports = {WebhookClient, Text, Card, Image, Suggestion, Payload};
+module.exports = {WebhookClient, Text, Card, Image, Suggestion, Payload, Platforms: PLATFORMS};


### PR DESCRIPTION
This is necessary to access Platforms in a .ts file.

For example:
new Payload(Platforms.UNSPECIFIED,
            payload, {rawPayload: true, sendAsMessage: true})

The platforms are not exposed any where publicly. From the js examples I've seen online, most people access the platforms by WebhookClient.Platform. This doesn't work with ts because WebhookClient.Platform is not an explicit method or a field.

[The @types/dialogflow-fulfillment exports the platforms](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/dialogflow-fulfillment/index.d.ts#L13).

[Without exposing it, we get a run time error because the dialogflow-fulfillment.d.ts is not compiled and the .js does not expose the platforms](https://lukasbehal.com/2017-05-22-enums-in-declaration-files/).  So, [the solution is to also export it from the .js](https://github.com/microsoft/TypeScript/issues/37120#issuecomment-592783135) .